### PR TITLE
Fix GitHub issues to allow building, and MacPorts support

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -105,9 +105,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
 
   native.new_http_archive(
     name = "gmock_archive",
-    url = "http://pkgs.fedoraproject.org/repo/pkgs/gmock/gmock-1.7.0.zip/073b984d8798ea1594f5e44d85b20d66/gmock-1.7.0.zip",
-    sha256 = "26fcbb5925b74ad5fc8c26b0495dfc96353f4d553492eb97e85a8a6d2f43095b",
-    strip_prefix = "gmock-1.7.0",
+    url = "https://github.com/paulsapps/gmock-1.7.0/archive/master.zip",
     build_file = str(Label("//:gmock.BUILD")),
   )
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -85,7 +85,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
 
   native.new_http_archive(
     name = "six_archive",
-    url = "http://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
+    url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
     sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
     strip_prefix = "six-1.10.0",
     build_file = str(Label("//:six.BUILD")),

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -35,7 +35,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
   native.http_archive(
     name = "gemmlowp",
     url = "http://github.com/google/gemmlowp/archive/8b20dd2ce142115857220bd6a35e8a081b3e0829.tar.gz",
-    sha256 = "9cf5f1e3d64b3632dbae5c65efb79f4374ca9ac362d788fc61e086af937ff6d7",
+    sha256 = "4fbbf7b8c41dd9d2d2500a594bcda70a5be7b64d607c1556b1be9737b2396e16",
     strip_prefix = "gemmlowp-8b20dd2ce142115857220bd6a35e8a081b3e0829",
   )
 
@@ -141,7 +141,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
   native.new_http_archive(
     name = "grpc",
     url = "http://github.com/grpc/grpc/archive/d7ff4ff40071d2b486a052183e3e9f9382afb745.tar.gz",
-    sha256 = "a15f352436ab92c521b1ac11e729e155ace38d0856380cf25048c5d1d9ba8e31",
+    sha256 = "81a20a2462cac1df00caa5ea9c05ced4633d657b19ed1ec3c6cf6e4f2bdbfce9",
     strip_prefix = "grpc-d7ff4ff40071d2b486a052183e3e9f9382afb745",
     build_file = str(Label("//:grpc.BUILD")),
   )

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -99,7 +99,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
   native.http_archive(
     name = "protobuf",
     url = "http://github.com/google/protobuf/archive/v3.1.0.tar.gz",
-    sha256 = "0a0ae63cbffc274efb573bdde9a253e3f32e458c41261df51c5dbc5ad541e8f7",
+    sha256 = "fb2a314f4be897491bb2446697be693d489af645cb0e165a85e7e64e07eb134d",
     strip_prefix = "protobuf-3.1.0",
   )
 

--- a/util/install_deps_mac.sh
+++ b/util/install_deps_mac.sh
@@ -5,13 +5,25 @@
 # - already have xcode and command-line tools installed
 # - running from root of the already cloned tf-coriander repo
 
+
+if [ -x '/opt/local/bin/port' ]; then
+  echo "Getting dependencies with MacPorts."
+  sudo port install autoconf automake libtool gflags python36
+  PYTHON=python3.6
+elif [ -x '/usr/local/bin/brew' ]; then
+  echo "Getting dependencies with Brew."
+  brew install autoconf automake libtool shtool gflags python3
+  PYTHON=python3
+else
+  echo "Could not find MacPorts or Brew in standard locations, aborting."
+fi
+
+
 set -e
 set -x
 
-brew install autoconf automake libtool shtool gflags python3
-
 if [[ ! -d env3 ]]; then {
-    python3 -m venv env3
+    $PYTHON -m venv env3
 } fi
 
 source env3/bin/activate

--- a/util/requirements.txt
+++ b/util/requirements.txt
@@ -2,3 +2,4 @@ numpy
 pytest
 pep8
 pytest-pep8
+wheel


### PR DESCRIPTION
This PR revives the project, fix a wheel issue, and adds the MacPorts package manager for Darwin users. In slightly more details:

* GitHub invalidated archive checksum hashes, around last November, apparently after a `zlib` update on their file servers. I can retrieve reference links if necessary. This "update" allows to build again. I have tested successful production of the module.
* A commit adds the `wheel` package to the `util/requirements.txt` file. Without it, the build fails at the very end, for the missing `bdist_wheel` target.
* The setup script can now automatically install dependencies with MacPorts for Darwin users.
